### PR TITLE
Allow logging to stdout

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,12 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
To host tiny-maven-repository on ECS, I want it to print logs to stdout. Added `RAILS_LOG_TO_STDOUT` environment variable to switch it, which is [generated in Rails 5 by default](https://github.com/rails/rails/blob/v5.0.0.1/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L84-L88).

@gfx What do you think?