### PR TITLE
Allow serving statis files on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_files = false
+  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
Since performance of assets is not a big deal for tiny-maven-repository, I want to serve static files by rails server.
Added [RAILS_SERVE_STATIC_FILES](https://github.com/rails/rails/blob/v5.0.0.1/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L19) environment variable to switch `config.serve_static_files`.

@gfx @eagletmt Could you review this?
